### PR TITLE
Feature/gfs utils update

### DIFF
--- a/parm/post/oceanice_products.yaml
+++ b/parm/post/oceanice_products.yaml
@@ -2,6 +2,8 @@ ocnicepost:
   executable: "ocnicepost.x"
   namelist:
     debug: False
+    write_grib2: False
+    write_netcdf: False
   fix_data:
     mkdir:
       - "{{ DATA }}"

--- a/parm/post/oceanice_products.yaml
+++ b/parm/post/oceanice_products.yaml
@@ -3,7 +3,7 @@ ocnicepost:
   namelist:
     debug: False
     write_grib2: False
-    write_netcdf: False
+    write_netcdf: True
   fix_data:
     mkdir:
       - "{{ DATA }}"

--- a/ush/python/pygfs/task/oceanice_products.py
+++ b/ush/python/pygfs/task/oceanice_products.py
@@ -139,6 +139,8 @@ class OceanIceProducts(Task):
         localconf.cosvar = config.oceanice_yaml[config.component].namelist.cosvar
         localconf.angvar = config.oceanice_yaml[config.component].namelist.angvar
         localconf.debug = ".true." if config.oceanice_yaml.ocnicepost.namelist.debug else ".false."
+        localconf.write_grib2 = ".true." if config.oceanice_yaml.ocnicepost.namelist.write_grib2 else ".false."
+        localconf.write_netcdf = ".true." if config.oceanice_yaml.ocnicepost.namelist.write_netcdf else ".false."
 
         logger.debug(f"localconf:\n{pformat(localconf)}")
 


### PR DESCRIPTION
Patch PR for gfs-utils update.
Full disclosure, I don't know if PR [99](https://github.com/NOAA-EMC/gfs-utils/pull/99) in gfs-utils actually kept the netCDF capability intact or broke it.  I hope it didn't break the netCDF capability, but if it did, revert this PR and we can open an issue in gfs-utils and make the developer address it.